### PR TITLE
create solc standard json input from truffle compiled json sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -217,6 +217,11 @@
         "@ethersproject/strings": "^5.0.4"
       }
     },
+    "@openzeppelin/contracts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.1.0.tgz",
+      "integrity": "sha512-dVXDnUKxrAKLzPdCRkz+N8qsVkK1XxJ6kk3zuI6zaQmcKxN7CkizoDP7lXxcs/Mi2I0mxceTRjJBqlzFffLJrQ=="
+    },
     "@orbs-network/orbs-ethereum-contracts-v2": {
       "version": "0.0.38",
       "resolved": "https://registry.npmjs.org/@orbs-network/orbs-ethereum-contracts-v2/-/orbs-ethereum-contracts-v2-0.0.38.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@orbs-network/orbs-ethereum-contracts-v2": "0.0.38",
     "ganache-cli": "^6.11.0",
-    "web3": "^1.3.0"
+    "web3": "^1.3.0",
+    "@openzeppelin/contracts": "3.1.x"
   }
 }

--- a/std-json-input.js
+++ b/std-json-input.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+const path = require("path");
+
+async function main() {
+    const srcDir = process.argv[2];
+    const contractPath = process.argv[3];
+    console.log("🌾srcDir:", srcDir, "🏄‍contractPath:", contractPath);
+    if (!srcDir || !contractPath) throw new Error(`expected contracts src dir and truffle compiled contract json full paths`);
+    const json = JSON.parse(JSON.stringify(require(path.resolve(contractPath))));
+    const metadata = JSON.parse(json.metadata);
+
+    const sources = {};
+    for (let contractPath in metadata.sources) {
+        if (contractPath.startsWith("@openzeppelin/")) {
+            contractPath = path.resolve(process.cwd(), "node_modules", contractPath);
+        } else {
+            contractPath = contractPath.split(path.sep + path.basename(srcDir) + path.sep)[1];
+            contractPath = path.resolve(srcDir, contractPath);
+        }
+
+        const content = fs.readFileSync(contractPath, {encoding: "utf8"});
+        sources[contractPath] = {content};
+    }
+
+    const result = {
+        language: metadata.language,
+        sources,
+        settings: {
+            remappings: metadata.settings.remappings,
+            optimizer: metadata.settings.optimizer,
+            evmVersion: metadata.settings.evmVersion
+        }
+    }
+
+    const resultPath = path.resolve("./", `${path.basename(contractPath).split(".json")[0]}-input.json`);
+    const resultData = JSON.stringify(result, null, 4);
+    fs.writeFileSync(resultPath, resultData, {encoding: "utf8"});
+    console.log("💰wrote to", resultPath)
+
+    return "done"
+}
+
+main().catch(console.error).then(console.log)


### PR DESCRIPTION
after npm install and setting up env, this script converts precompiled truffle json output together with installed sources into what is known as [Solidity Standard Json Input](https://docs.soliditylang.org/en/develop/using-the-compiler.html) to be used for example with etherscan verification.

example of script execution to create the output for `ContractRegistry`:
```
node std-json-input.js node_modules/@orbs-network/orbs-ethereum-contracts-v2/contracts node_modules/@orbs-network/orbs-ethereum-contracts-v2/build/contracts/ContractRegistry.json
```